### PR TITLE
Fix undef handle in AnyEvent::HTTP callback

### DIFF
--- a/t/11-connerr.t
+++ b/t/11-connerr.t
@@ -1,0 +1,30 @@
+#!perl
+
+use strict;
+use warnings;
+
+use Net::Etcd;
+use Test::More tests => 3;
+use Test::Exception;
+use Cwd;
+
+my $config = {
+    host => 'localhost',
+    port => 123456,
+};
+my $dir = getcwd;
+my $etcd = Net::Etcd->new($config);
+
+my $range;
+
+lives_ok(
+    sub {
+        $range = $etcd->range( { key => 'foo1' } );
+    },
+    "kv range"
+);
+
+my $response = $range->response;
+
+cmp_ok( $response->{ success }, '==', 0, "Did not succeed" );
+cmp_ok( $response->{ headers }{ Status }, '==', 595, "Connection error" );


### PR DESCRIPTION
Issue: AnyEvent::HTTP returns undef as handle in the callback when an error occurs(e.g., comunication error, TLS failure). Solution: Added checks to handle cases where handle is undef to prevent potential crashes or undefined behavior.